### PR TITLE
Bug in section definition

### DIFF
--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -162,7 +162,7 @@ class DataStore(xr.Dataset):
 
     @sections.setter
     def sections(self, sections: Dict[str, List[slice]]):
-        sections_fix = None
+        sections_fix_slice_fixed = None
 
         if sections:
             assert isinstance(sections, dict)
@@ -187,6 +187,7 @@ class DataStore(xr.Dataset):
                                               'stored in ds.data_vars'
 
             sections_fix_slice_fixed = dict()
+
             for k, v in sections_fix.items():
                 assert isinstance(v, (list, tuple)), \
                     'The values of the sections-dictionary ' \

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -186,6 +186,7 @@ class DataStore(xr.Dataset):
                                               'to a valid timeserie already ' \
                                               'stored in ds.data_vars'
 
+            sections_fix_slice_fixed = dict()
             for k, v in sections_fix.items():
                 assert isinstance(v, (list, tuple)), \
                     'The values of the sections-dictionary ' \
@@ -201,7 +202,10 @@ class DataStore(xr.Dataset):
                         f'Better define the {k} section. You tried {vi}, ' \
                         'which is out of reach'
 
-        self.attrs['_sections'] = yaml.dump(sections_fix)
+                sections_fix_slice_fixed[k] = [
+                    slice(float(vi.start), float(vi.stop)) for vi in v]
+
+        self.attrs['_sections'] = yaml.dump(sections_fix_slice_fixed)
         pass
 
     @sections.deleter

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -163,6 +163,11 @@ def test_sections_property():
     assert ds.sections == sections1
     assert ds.sections != sections2
 
+    # test if accepts singleton numpy arrays
+    ds.sections = {
+        'probe1Temperature': [
+            slice(np.array(0.), np.array(17.)), slice(70., 80.)]}
+
     # delete property
     del ds.sections
     assert ds.sections is None


### PR DESCRIPTION
Error would occur when the slices used for section definition would be:
slice(np.array(3.5), np.array(4.4))
Bug reported by Robert Law.

Signed-off-by: Bas des Tombe <bdestombe@gmail.com>