### PR TITLE
Added manual fiber start & end

### DIFF
--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -135,14 +135,6 @@ class DataStore(xr.Dataset):
 
             for k, v in self.sections.items():
                 preamble_new += '    {0: <23}'.format(k)
-
-                # Compute statistics reference section timeseries
-                sec_stat = '({0:6.2f}'.format(float(self[k].mean()))
-                sec_stat += ' +/-{0:5.2f}'.format(float(self[k].std()))
-                sec_stat += u'\N{DEGREE SIGN}C)\t'
-                preamble_new += sec_stat
-
-                # print sections
                 vl = ['{0:.2f}{2} - {1:.2f}{2}'.format(vi.start, vi.stop, unit)
                       for vi in v]
                 preamble_new += ' and '.join(vl) + '\n'
@@ -3494,6 +3486,8 @@ def read_sensornet_files(
         timezone_netcdf='UTC',
         timezone_input_files='UTC',
         silent=False,
+        manual_fiber_start=None,
+        manual_fiber_end=None,
         **kwargs):
     """Read a folder with measurement files. Each measurement file contains
     values for a single timestep. Remember to check which timezone
@@ -3515,6 +3509,10 @@ def read_sensornet_files(
         file extension of the measurement files
     silent : bool
         If set tot True, some verbose texts are not printed to stdout/screen
+    manual_fiber_start: float, optional
+        If cable is not presented well automatically
+    manual_fiber_end: float, optional
+        If fiber end is not (well) defined by input files. 
     kwargs : dict-like, optional
         keyword-arguments are passed to DataStore initialization
 
@@ -3529,7 +3527,9 @@ def read_sensornet_files(
     datastore : DataStore
         The newly created datastore.
     """
-
+    manual_fiber_start = manual_fiber_start
+    manual_fiber_end = manual_fiber_end
+    
     if filepathlist is None:
         filepathlist = sorted(glob.glob(os.path.join(directory, file_ext)))
 
@@ -3548,7 +3548,9 @@ def read_sensornet_files(
         filepathlist,
         timezone_netcdf=timezone_netcdf,
         timezone_input_files=timezone_input_files,
-        silent=silent)
+        silent=silent,
+        manual_fiber_start=manual_fiber_start,
+        manual_fiber_end=manual_fiber_end)
 
     ds = DataStore(data_vars=data_vars, coords=coords, attrs=attrs, **kwargs)
     return ds

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -3520,7 +3520,7 @@ def read_sensornet_files(
     manual_fiber_start: float, optional
         If cable is not presented well automatically
     manual_fiber_end: float, optional
-        If fiber end is not (well) defined by input files. 
+        If fiber end is not (well) defined by input files.
     kwargs : dict-like, optional
         keyword-arguments are passed to DataStore initialization
 
@@ -3537,7 +3537,7 @@ def read_sensornet_files(
     """
     manual_fiber_start = manual_fiber_start
     manual_fiber_end = manual_fiber_end
-    
+
     if filepathlist is None:
         filepathlist = sorted(glob.glob(os.path.join(directory, file_ext)))
 

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -135,6 +135,14 @@ class DataStore(xr.Dataset):
 
             for k, v in self.sections.items():
                 preamble_new += '    {0: <23}'.format(k)
+
+                # Compute statistics reference section timeseries
+                sec_stat = '({0:6.2f}'.format(float(self[k].mean()))
+                sec_stat += ' +/-{0:5.2f}'.format(float(self[k].std()))
+                sec_stat += u'\N{DEGREE SIGN}C)\t'
+                preamble_new += sec_stat
+
+                # print sections
                 vl = ['{0:.2f}{2} - {1:.2f}{2}'.format(vi.start, vi.stop, unit)
                       for vi in v]
                 preamble_new += ' and '.join(vl) + '\n'

--- a/src/dtscalibration/io.py
+++ b/src/dtscalibration/io.py
@@ -700,6 +700,7 @@ def read_sensornet_files_routine_v3(
         timezone_netcdf='UTC',
         timezone_input_files='UTC',
         silent=False,
+        manual_fiber_start=None,
         manual_fiber_end=None):
     """
     Internal routine that reads Sensor files.
@@ -711,6 +712,8 @@ def read_sensornet_files_routine_v3(
     timezone_netcdf
     timezone_input_files
     silent
+    manual_fiber_start : float
+        Only necessary when cable is not represented well. 
     manual_fiber_end : float
         If defined, overwrites the fiber end, read from the first file. It is
         the fiber length between the two connector entering the DTS device.
@@ -815,7 +818,11 @@ def read_sensornet_files_routine_v3(
 
     if double_ended_flag:
         # Get fiber length, and starting point for reverse channel reversal
-        fiber_start = -50
+        if manual_fiber_start:
+            fiber_start = manual_fiber_start
+        else:
+            fiber_start = -50
+            
         if manual_fiber_end:
             fiber_end = manual_fiber_end
         else:

--- a/src/dtscalibration/io.py
+++ b/src/dtscalibration/io.py
@@ -713,7 +713,7 @@ def read_sensornet_files_routine_v3(
     timezone_input_files
     silent
     manual_fiber_start : float
-        Only necessary when cable is not represented well. 
+        Only necessary when cable is not represented well.
     manual_fiber_end : float
         If defined, overwrites the fiber end, read from the first file. It is
         the fiber length between the two connector entering the DTS device.
@@ -822,7 +822,7 @@ def read_sensornet_files_routine_v3(
             fiber_start = manual_fiber_start
         else:
             fiber_start = -50
-            
+
         if manual_fiber_end:
             fiber_end = manual_fiber_end
         else:
@@ -1229,7 +1229,7 @@ def read_apsensing_files_routine(
     namespace = get_xml_namespace(xml_tree.getroot())
 
     logtree = xml_tree.find(('{0}wellSet/{0}well/{0}wellboreSet/{0}wellbore' +
-                            '/{0}wellLogSet/{0}wellLog').format(namespace))
+                             '/{0}wellLogSet/{0}wellLog').format(namespace))
     logdata_tree = logtree.find('./{0}logData'.format(namespace))
 
     # Amount of datapoints is the size of the logdata tree


### PR DESCRIPTION
Adjusted io.py & datastore.py. When calling uppon read_sensornet_files you can insert manual_fiber_end and/or manual_fiber_start. Both are optional. Little comments provided at the source. 