### PR TITLE
Bugfixes April 2020

### DIFF
--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -110,6 +110,11 @@ class DataStore(xr.Dataset):
                         dim for dim in ideal_dim if dim in (var.dims + (...,)))
                     self._variables[name] = var.transpose(*var_dims)
 
+        # Get attributes from dataset
+        for arg in args:
+            if isinstance(arg, xr.Dataset):
+                self.attrs = arg.attrs
+
         if '_sections' not in self.attrs:
             self.attrs['_sections'] = yaml.dump(None)
 
@@ -195,8 +200,8 @@ class DataStore(xr.Dataset):
         -------
 
         """
-        if not hasattr(self, '_sections'):
-            self.attrs['_sections'] = 'null\n...\n'
+        if '_sections' not in self.attrs:
+            self.attrs['_sections'] = yaml.dump(None)
         return yaml.load(self.attrs['_sections'], Loader=yaml.UnsafeLoader)
 
     @sections.setter

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -195,7 +195,8 @@ class DataStore(xr.Dataset):
         -------
 
         """
-        assert hasattr(self, '_sections'), 'first set the sections'
+        if not hasattr(self, '_sections'):
+            self.attrs['_sections'] = 'null\n...\n'
         return yaml.load(self.attrs['_sections'], Loader=yaml.UnsafeLoader)
 
     @sections.setter

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -1942,6 +1942,12 @@ class DataStore(xr.Dataset):
             'There is uncontrolled noise in the REV-AST signal. Are your ' \
             'sections correctly defined?'
 
+        if method == 'wls':
+            for input_item in [st_var, ast_var, rst_var, rast_var]:
+                assert input_item is not None, \
+                    'For wls define all variances (`st_var`, `ast_var`,' +\
+                    ' `rst_var`, `rast_var`)'
+
         if np.any(matching_indices):
             assert not matching_sections, \
                 'Either define `matching_sections` or `matching_indices`'
@@ -2526,7 +2532,7 @@ class DataStore(xr.Dataset):
 
         # store variances in DataStore
         if method == 'wls' or method == 'external':
-            # the variances only have ameaning if the observations are weighted
+            # the variances only have meaning if the observations are weighted
             gammavar = p_var[0]
             dfvar = p_var[1:nt + 1]
             dbvar = p_var[1 + nt:1 + 2 * nt]

--- a/src/dtscalibration/datastore_utils.py
+++ b/src/dtscalibration/datastore_utils.py
@@ -161,7 +161,7 @@ def merge_double_ended(ds_fw, ds_bw, cable_length, plot_result=True):
     return ds
 
 
-def shift_double_ended(ds, i_shift):
+def shift_double_ended(ds, i_shift, verbose=True):
     """
     The cable length was initially configured during the DTS measurement. For double ended
     measurements it is important to enter the correct length so that the forward channel and the
@@ -184,7 +184,10 @@ def shift_double_ended(ds, i_shift):
     i_shift : int
         if i_shift < 0, the cable was configured to be too long and there is too much data
         recorded. If i_shift > 0, the cable was configured to be too short and part of the cable is
-        not measured.
+        not measured
+    verbose: bool
+        If True, the function will inform the user which variables are
+        dropped. If False, the function will silently drop the variables.
 
     Returns
     -------
@@ -231,7 +234,7 @@ def shift_double_ended(ds, i_shift):
         d2_data[k] = (ds[k].dims, v, ds[k].attrs)
 
     not_included = [k for k in ds.data_vars if k not in d2_data]
-    if not_included:
+    if (not_included and verbose):
         print('I dont know what to do with the following data', not_included)
 
     return DataStore(data_vars=d2_data, coords=d2_coords, attrs=ds.attrs)


### PR DESCRIPTION
Fixes #104, #105, #107 

- Re-adds the _sections attribute when calling datastore.sections if it is missing.
- Obtains attributes from dataset when creating a datastore from a dataset
- shift_double_ended can be silenced (no print to console)
- Check if variance kwargs are passed to calibration_double_ended for the wls calibration. Return a clear error if they are missing.