### PR TITLE
[WIP] WLS_sparse2 solver

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,20 @@
 
 Changelog
 =========
+1.0.3 (UNRELEASED)
+------------------
+New features
+
+*
+
+Bug fixes
+
+*
+
+Others
+
+*
+
 1.0.2 (2020-05-04)
 ------------------
 * Same as v1.0.1


### PR DESCRIPTION
Introduces a new solver that accepts prior knowledge of the parameter set. And should generally be faster than `wls_spare`.

    Solves the normal equations of X . p_sol = y with weights. Supports a priori
    information. The parameter estimates from a previous calibration instance
    and their covariances can be passed to `p_sol_prior` and `p_cov_prior`.
    Allows for sequential calibration in chunks.

    Normally, the X matrix is very tall (nobs>>npar), more observations than
    unknowns. By using the normal equations, the coefficient matrix reduces to a
    square matrix of shape (npar, npar), and the observation matrix to (npar,).
    This results in a much smaller system to solve.

Todo:
- Test / demo that sequential calibration works
- Similar tests as the other solvers
- Basic implementation in the `ds.calibration_single_ended()` and `ds.calibration_double_ended()` functions.
- Example notebook