### PR TITLE
transient_att_x renamed to trans_att

### DIFF
--- a/examples/notebooks/05Calibrate_single_ols.ipynb
+++ b/examples/notebooks/05Calibrate_single_ols.ipynb
@@ -199,7 +199,7 @@
       "            has three items. The first two items are the slices of the sections\n",
       "            that are matched. The third item is a boolean and is True if the two\n",
       "            sections have a reverse direction (\"J-configuration\").\n",
-      "        transient_att_x : iterable, optional\n",
+      "        trans_att : iterable, optional\n",
       "            Splices can cause jumps in differential attenuation. Normal single\n",
       "            ended calibration assumes these are not present. An additional loss\n",
       "            term is added in the 'shadow' of the splice. Each location\n",

--- a/examples/notebooks/06Calibrate_double_ols.ipynb
+++ b/examples/notebooks/06Calibrate_double_ols.ipynb
@@ -267,7 +267,7 @@
       "            memory, is faster, and gives the same result as the statsmodels\n",
       "            solver. The statsmodels solver is mostly used to check the sparse\n",
       "            solver. `'stats'` is the default.\n",
-      "        transient_asym_att_x : iterable of float, optional\n",
+      "        trans_att : iterable of float, optional\n",
       "            Connectors cause assymetrical attenuation. Normal double ended\n",
       "            calibration assumes symmetrical attenuation. An additional loss\n",
       "            term is added in the 'shadow' of the forward and backward\n",

--- a/examples/notebooks/07Calibrate_single_wls.ipynb
+++ b/examples/notebooks/07Calibrate_single_wls.ipynb
@@ -203,7 +203,7 @@
       "            has three items. The first two items are the slices of the sections\n",
       "            that are matched. The third item is a boolean and is True if the two\n",
       "            sections have a reverse direction (\"J-configuration\").\n",
-      "        transient_att_x : iterable, optional\n",
+      "        trans_att : iterable, optional\n",
       "            Splices can cause jumps in differential attenuation. Normal single\n",
       "            ended calibration assumes these are not present. An additional loss\n",
       "            term is added in the 'shadow' of the splice. Each location\n",

--- a/examples/notebooks/14Lossy_splices.ipynb
+++ b/examples/notebooks/14Lossy_splices.ipynb
@@ -202,9 +202,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we run a calibration, adding the keyword argument '**transient_asym_att_x**', and provide a list of floats containing the locations of the splices. In this case we only add a single one at x = 50 m. After running the calibration you will see that by adding the transient attenuation location the calibration returns the correct temperature, without the big jump.\n",
+    "Now we run a calibration, adding the keyword argument '**trans_att**', and provide a list of floats containing the locations of the splices. In this case we only add a single one at x = 50 m. After running the calibration you will see that by adding the transient attenuation location the calibration returns the correct temperature, without the big jump.\n",
     "\n",
-    "*In single-ended calibration the keyword is called '**transient_att_x**'.*"
+    "*In single-ended calibration the keyword is called '**trans_att**'.*"
    ]
   },
   {
@@ -246,7 +246,7 @@
     "    ast_var=ast_var,\n",
     "    rst_var=rst_var,\n",
     "    rast_var=rast_var,\n",
-    "    transient_asym_att_x=[50.],\n",
+    "    trans_att=[50.],\n",
     "    store_tmpw='tmpw',\n",
     "    method='wls',\n",
     "    solver='sparse')\n",

--- a/examples/notebooks/15Matching_sections.ipynb
+++ b/examples/notebooks/15Matching_sections.ipynb
@@ -162,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we run a calibration, adding the keyword argument '**transient_asym_att_x**', and provide a list of floats containing the locations of the splices. In this case we only add a single one at x = 50 m.\n",
+    "Now we run a calibration, adding the keyword argument '**trans_att**', and provide a list of floats containing the locations of the splices. In this case we only add a single one at x = 50 m.\n",
     "\n",
     "We will also define the matching sections of cable. The matching sections have to be provided as a list of tuples. A tuple per matching section. Each tuple has three items, the first two items are the slices of the sections that are matching. The third item is a bool and is True if the two sections have a reverse direction (as in the \"J-configuration\").\n",
     "\n",
@@ -170,7 +170,7 @@
     "\n",
     "After running the calibration you will see that by adding the transient attenuation and matching sections the calibration returns the correct temperature, without the big jump.\n",
     "\n",
-    "*In single-ended calibration the keyword is called '**transient_att_x**'.*"
+    "*In single-ended calibration the keyword is called '**trans_att**'.*"
    ]
   },
   {
@@ -224,7 +224,7 @@
     "    ast_var=ast_var,\n",
     "    rst_var=rst_var,\n",
     "    rast_var=rast_var,\n",
-    "    transient_asym_att_x=[50.],\n",
+    "    trans_att=[50.],\n",
     "    matching_sections=matching_sections,\n",
     "    store_tmpw='tmpw',\n",
     "    method='wls',\n",

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -38,6 +38,7 @@ from .io import ziphandle_to_filepathlist
 dtsattr_namelist = ['double_ended_flag']
 dim_attrs = {k: v for kl, v in _dim_attrs.items() for k in kl}
 
+
 class DataStore(xr.Dataset):
     """The data class that stores the measurements, contains calibration
     methods to relate Stokes and anti-Stokes to temperature. The user should

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -1771,13 +1771,13 @@ class DataStore(xr.Dataset):
         if 'transient_att_x' in kwargs:
             warnings.warn(
                 "transient_att_x argument will be deprecated in version 2, "
-                "use trans_att", PendingDeprecationWarning)
+                "use trans_att", DeprecationWarning)
             trans_att = kwargs['transient_att_x']
 
         if 'transient_asym_att_x' in kwargs:
             warnings.warn(
                 "transient_asym_att_x arg will be deprecated in version 2, "
-                "use trans_att", PendingDeprecationWarning)
+                "use trans_att", DeprecationWarning)
             trans_att = kwargs['transient_asym_att_x']
 
         if 'trans_att' in self.coords and self.trans_att.size > 0:

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -111,7 +111,7 @@ class DataStore(xr.Dataset):
                     self._variables[name] = var.transpose(*var_dims)
 
         if 'trans_att' not in self.coords:
-            self.trans_att = []
+            self.set_trans_att(trans_att=[])
 
         # Get attributes from dataset
         for arg in args:
@@ -1796,7 +1796,7 @@ class DataStore(xr.Dataset):
         if trans_att is None:
             trans_att = []
 
-        self.trans_att = trans_att
+        self['trans_att'] = trans_att
         self.trans_att.attrs = dim_attrs['trans_att']
         pass
 
@@ -3257,7 +3257,7 @@ dtscalibration/python-dts-calibration/blob/master/examples/notebooks/\
             self.conf_int_double_ended(
                 p_val=p_val,
                 p_cov=p_cov,
-                store_ta=store_ta if self.trans_att.values else None,
+                store_ta=store_ta if self.trans_att.size > 0 else None,
                 st_var=st_var,
                 ast_var=ast_var,
                 rst_var=rst_var,

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -1784,14 +1784,18 @@ class DataStore(xr.Dataset):
         if 'trans_att' in self.coords and self.trans_att.size > 0:
             raise_warning = 0
 
+            del_keys = []
             for k, v in self.data_vars.items():
                 if 'trans_att' in v.dims:
-                    del self[k]
-                    raise_warning += 1
+                    del_keys.append(k)
+
+            for del_key in del_keys:
+                del self[del_key]
 
             if raise_warning:
                 m = 'trans_att was set before. All `data_vars` that make use ' \
-                    'of the `trans_att` coordinates were deleted'
+                    'of the `trans_att` coordinates were deleted: ' + \
+                    str(del_keys)
                 warnings.warn(m)
 
         if trans_att is None:
@@ -2016,7 +2020,7 @@ dtscalibration/python-dts-calibration/blob/master/examples/notebooks/\
         """
         self.check_deprecated_kwargs(kwargs)
 
-        self.set_trans_att(trans_att=trans_att)
+        self.set_trans_att(trans_att=trans_att, **kwargs)
 
         if sections:
             self.sections = sections
@@ -2586,7 +2590,7 @@ dtscalibration/python-dts-calibration/blob/master/examples/notebooks/\
         """
         self.check_deprecated_kwargs(kwargs)
 
-        self.set_trans_att(trans_att=trans_att)
+        self.set_trans_att(trans_att=trans_att, **kwargs)
 
         if sections:
             self.sections = sections

--- a/src/dtscalibration/io.py
+++ b/src/dtscalibration/io.py
@@ -49,7 +49,17 @@ _dim_attrs = {
             description='Measurement duration of backward channel',
             long_description='Desired measurement duration of backward '
             'channel',
-            units='seconds')}
+            units='seconds'),
+    ('trans_att',):
+        dict(
+            name='Locations introducing transient directional differential '
+                 'attenuation',
+            description='Locations along the x-dimension introducing transient '
+                        'directional differential attenuation',
+            long_description='Connectors introduce additional differential '
+                             'attenuation that is different for the forward '
+                             'and backward direction, and varies over time.',
+            units='m')}
 
 # Because variations in the names exist between the different file formats. The
 #   tuple as key contains the possible keys, which is expanded below.

--- a/tests/test_dtscalibration.py
+++ b/tests/test_dtscalibration.py
@@ -1345,6 +1345,36 @@ def test_double_ended_asymmetrical_attenuation():
     assert_almost_equal_verbose(temp_real_celsius, ds.tmpf.values, decimal=7)
     assert_almost_equal_verbose(temp_real_celsius, ds.tmpb.values, decimal=7)
     assert_almost_equal_verbose(temp_real_celsius, ds.tmpw.values, decimal=7)
+
+    # test `trans_att` related functions
+
+    # Clear out old results
+    ds.set_trans_att([])
+
+    assert ds.trans_att.size == 0, 'clear out trans_att config'
+
+    del_keys = []
+    for k, v in ds.data_vars.items():
+        if 'trans_att' in v.dims:
+            del_keys.append(k)
+
+    assert len(del_keys) == 0, 'clear out trans_att config'
+
+    # About to be depreciated
+    ds.calibration_double_ended(
+        st_var=1.5,
+        ast_var=1.5,
+        rst_var=1.,
+        rast_var=1.,
+        method='wls',
+        solver='sparse',
+        tmpw_mc_size=1000,
+        remove_mc_set_flag=True,
+        transient_asym_att_x=[50.])
+
+    assert_almost_equal_verbose(temp_real_celsius, ds.tmpf.values, decimal=7)
+    assert_almost_equal_verbose(temp_real_celsius, ds.tmpb.values, decimal=7)
+    assert_almost_equal_verbose(temp_real_celsius, ds.tmpw.values, decimal=7)
     pass
 
 
@@ -2924,6 +2954,35 @@ def test_single_ended_trans_att_synthetic():
         ast_var=1.0,
         method='wls',
         trans_att=[40, 60],
+        solver='sparse')
+
+    assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=8)
+    assert_almost_equal_verbose(
+        ds_test.tmpf.values, temp_real - 273.15, decimal=8)
+    assert_almost_equal_verbose(
+        ds_test.isel(trans_att=0).talpha, -np.log(tr_att), decimal=8)
+    assert_almost_equal_verbose(
+        ds_test.isel(trans_att=1).talpha, -np.log(tr_att2), decimal=8)
+
+    # test `trans_att` related functions
+    # Clear out old results
+    ds_test.set_trans_att([])
+
+    assert ds_test.trans_att.size == 0, 'clear out trans_att config'
+
+    del_keys = []
+    for k, v in ds_test.data_vars.items():
+        if 'trans_att' in v.dims:
+            del_keys.append(k)
+
+    assert len(del_keys) == 0, 'clear out trans_att config'
+
+    ds_test.calibration_single_ended(
+        sections=sections,
+        st_var=1.0,
+        ast_var=1.0,
+        method='wls',
+        transient_att_x=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=8)

--- a/tests/test_dtscalibration.py
+++ b/tests/test_dtscalibration.py
@@ -14,6 +14,23 @@ from dtscalibration.cli import main
 
 np.random.seed(0)
 
+def assert_almost_equal_verbose(actual, desired, verbose=False, **kwargs):
+    """Print the actual precision decimals"""
+    err = np.abs(actual - desired).max()
+    dec = -np.ceil(np.log10(err))
+
+    if not (np.isfinite(dec)):
+        dec = 18.
+
+    m = "\n>>>>>The actual precision is: " + str(float(dec))
+
+    if verbose:
+        print(m)
+
+    desired2 = np.broadcast_to(desired, actual.shape)
+    np.testing.assert_almost_equal(actual, desired2, err_msg=m, **kwargs)
+    pass
+
 fn = [
     "channel 1_20170921112245510.xml", "channel 1_20170921112746818.xml",
     "channel 1_20170921112746818.xml"]
@@ -1339,7 +1356,7 @@ def test_double_ended_asymmetrical_attenuation():
         solver='sparse',
         tmpw_mc_size=1000,
         remove_mc_set_flag=True,
-        transient_asym_att_x=[50.])
+        trans_att=[50.])
 
     assert_almost_equal_verbose(temp_real_celsius, ds.tmpf.values, decimal=7)
     assert_almost_equal_verbose(temp_real_celsius, ds.tmpb.values, decimal=7)
@@ -1430,7 +1447,7 @@ def test_double_ended_one_matching_section_and_one_asym_att():
         solver='sparse',
         tmpw_mc_size=3,
         remove_mc_set_flag=True,
-        transient_asym_att_x=[50.],
+        trans_att=[50.],
         matching_sections=[
             (
                 slice(x[3 * nx_per_sec], x[4 * nx_per_sec - 1]),
@@ -1539,7 +1556,7 @@ def test_double_ended_two_matching_sections_and_two_asym_atts():
         solver='sparse',
         tmpw_mc_size=3,
         remove_mc_set_flag=True,
-        transient_asym_att_x=[x[3 * nx_per_sec], x[6 * nx_per_sec]],
+        trans_att=[x[3 * nx_per_sec], x[6 * nx_per_sec]],
         matching_sections=ms)
 
     assert_almost_equal_verbose(temp_real_celsius, ds.tmpf.values, decimal=7)
@@ -1927,7 +1944,7 @@ def test_double_ended_fix_alpha_matching_sections_and_one_asym_att():
         solver='sparse',
         tmpw_mc_size=3,
         remove_mc_set_flag=True,
-        transient_asym_att_x=[50.],
+        trans_att=[50.],
         matching_sections=[
             (
                 slice(x[3 * nx_per_sec], x[4 * nx_per_sec - 1]),
@@ -1953,7 +1970,7 @@ def test_double_ended_fix_alpha_matching_sections_and_one_asym_att():
         tmpw_mc_size=3,
         remove_mc_set_flag=True,
         fix_alpha=(alpha_adj, alpha_var_adj),
-        transient_asym_att_x=[50.],
+        trans_att=[50.],
         matching_sections=[
             (
                 slice(x[3 * nx_per_sec], x[4 * nx_per_sec - 1]),
@@ -2048,7 +2065,7 @@ def test_double_ended_fix_alpha_gamma_matching_sections_and_one_asym_att():
         solver='sparse',
         tmpw_mc_size=3,
         remove_mc_set_flag=True,
-        transient_asym_att_x=[50.],
+        trans_att=[50.],
         matching_sections=[
             (
                 slice(x[3 * nx_per_sec], x[4 * nx_per_sec - 1]),
@@ -2075,7 +2092,7 @@ def test_double_ended_fix_alpha_gamma_matching_sections_and_one_asym_att():
         remove_mc_set_flag=True,
         fix_alpha=(alpha_adj, alpha_var_adj),
         fix_gamma=(gamma, 0.),
-        transient_asym_att_x=[50.],
+        trans_att=[50.],
         matching_sections=[
             (
                 slice(x[3 * nx_per_sec], x[4 * nx_per_sec - 1]),
@@ -2171,7 +2188,7 @@ def test_double_ended_fix_gamma_matching_sections_and_one_asym_att():
         tmpw_mc_size=3,
         fix_gamma=(gamma, 0.),
         remove_mc_set_flag=True,
-        transient_asym_att_x=[50.],
+        trans_att=[50.],
         matching_sections=[
             (
                 slice(x[3 * nx_per_sec], x[4 * nx_per_sec - 1]),
@@ -2903,7 +2920,7 @@ def test_single_ended_trans_att_synthetic():
     ds_test.calibration_single_ended(
         sections=sections,
         method='ols',
-        transient_att_x=[40, 60],
+        trans_att=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=8)
@@ -2922,7 +2939,7 @@ def test_single_ended_trans_att_synthetic():
         st_var=1.0,
         ast_var=1.0,
         method='wls',
-        transient_att_x=[40, 60],
+        trans_att=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=8)
@@ -2942,7 +2959,7 @@ def test_single_ended_trans_att_synthetic():
         ast_var=1.0,
         method='wls',
         fix_gamma=(482.6, 0),
-        transient_att_x=[40, 60],
+        trans_att=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=10)
@@ -2962,7 +2979,7 @@ def test_single_ended_trans_att_synthetic():
         ast_var=1.0,
         method='wls',
         fix_dalpha=(6.46e-05, 0),
-        transient_att_x=[40, 60],
+        trans_att=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=8)
@@ -3054,7 +3071,7 @@ def test_single_ended_matching_sections_synthetic():
         sections=sections,
         method='ols',
         matching_sections=matching_sections,
-        transient_att_x=[40, 60],
+        trans_att=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=8)
@@ -3074,7 +3091,7 @@ def test_single_ended_matching_sections_synthetic():
         ast_var=1.0,
         method='wls',
         matching_sections=matching_sections,
-        transient_att_x=[40, 60],
+        trans_att=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=8)
@@ -3095,7 +3112,7 @@ def test_single_ended_matching_sections_synthetic():
         method='wls',
         fix_gamma=(482.6, 0),
         matching_sections=matching_sections,
-        transient_att_x=[40, 60],
+        trans_att=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=10)
@@ -3116,7 +3133,7 @@ def test_single_ended_matching_sections_synthetic():
         method='wls',
         fix_dalpha=(6.46e-05, 0),
         matching_sections=matching_sections,
-        transient_att_x=[40, 60],
+        trans_att=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=10)
@@ -3138,7 +3155,7 @@ def test_single_ended_matching_sections_synthetic():
         fix_gamma=(482.6, 0),
         fix_dalpha=(6.46e-05, 0),
         matching_sections=matching_sections,
-        transient_att_x=[40, 60],
+        trans_att=[40, 60],
         solver='sparse')
 
     assert_almost_equal_verbose(ds_test.gamma.values, gamma, decimal=10)

--- a/tests/test_dtscalibration.py
+++ b/tests/test_dtscalibration.py
@@ -14,22 +14,6 @@ from dtscalibration.cli import main
 
 np.random.seed(0)
 
-def assert_almost_equal_verbose(actual, desired, verbose=False, **kwargs):
-    """Print the actual precision decimals"""
-    err = np.abs(actual - desired).max()
-    dec = -np.ceil(np.log10(err))
-
-    if not (np.isfinite(dec)):
-        dec = 18.
-
-    m = "\n>>>>>The actual precision is: " + str(float(dec))
-
-    if verbose:
-        print(m)
-
-    desired2 = np.broadcast_to(desired, actual.shape)
-    np.testing.assert_almost_equal(actual, desired2, err_msg=m, **kwargs)
-    pass
 
 fn = [
     "channel 1_20170921112245510.xml", "channel 1_20170921112746818.xml",


### PR DESCRIPTION
`transient_att_x` and `transient_asym_att_x` are moved to `trans_att` coordinates. `trans_att` was already used to store the calibrate parameters. Removing those other names will reduce the codebase and prevent from weird bugs from happening with calibrated parameters that do not correspond with the `trans_att` coordinates. 

The arguments `transient_att_x` and `transient_asym_att_x` will be depreciated in version 2.0.