### PR TITLE
Updates for newer file format on Silixa devices.

### DIFF
--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -5505,7 +5505,7 @@ def read_silixa_files(
             silent=silent,
             load_in_memory=load_in_memory)
 
-    elif xml_version == 6 or 7:
+    elif xml_version in (6, 7, 8):
         data_vars, coords, attrs = read_silixa_files_routine_v6(
             filepathlist,
             xml_version=xml_version,

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -2112,7 +2112,7 @@ dtscalibration/python-dts-calibration/blob/master/examples/notebooks/\
             p_var = np.zeros_like(p_val)
             p_cov = np.zeros((p_val.size, p_val.size), dtype=np.float)
 
-            if fix_gamma:
+            if fix_gamma is not None:
                 ip_remove = [0]
                 ip_use = [i for i in ip_use if i not in ip_remove]
                 p_val[ip_remove] = fix_gamma[0]
@@ -2135,7 +2135,7 @@ dtscalibration/python-dts-calibration/blob/master/examples/notebooks/\
                 y -= split['X_alpha'].dot(fix_alpha[0])
                 w = 1 / (1 / w + split['X_alpha'].dot(fix_alpha[1]))
 
-            if fix_dalpha:
+            if fix_dalpha is not None:
                 ip_remove = [1]
                 ip_use = [i for i in ip_use if i not in ip_remove]
                 p_val[ip_remove] = fix_dalpha[0]

--- a/src/dtscalibration/io.py
+++ b/src/dtscalibration/io.py
@@ -434,6 +434,11 @@ def read_silixa_files_routine_v6(
                 tstamp = np.int64(file_name[10:27])
             elif xml_version == 7:
                 tstamp = np.int64(file_name[15:27])
+            elif xml_version == 8:  # need slightly more complex handling here
+                try:
+                    tstamp = np.int64(file_name[15:27])
+                except ValueError:
+                    tstamp = np.int64(file_name[-22:-10])
             else:
                 raise ValueError(
                     'Unknown version number: {}'.format(xml_version))


### PR DESCRIPTION
Data files with version 8 designation break along the v6 format load due to some naming conventions changes.  Some logical checks fail also without explicit checking for None.