### PR TITLE
Fix: np.float depracated converted to float

### DIFF
--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -2104,7 +2104,7 @@ dtscalibration/python-dts-calibration/blob/main/examples/notebooks/\
                 ip_use = list(range(1 + 1 + nt + nta * nt))
 
             p_var = np.zeros_like(p_val)
-            p_cov = np.zeros((p_val.size, p_val.size), dtype=np.float)
+            p_cov = np.zeros((p_val.size, p_val.size), dtype=float)
 
             if fix_gamma is not None:
                 ip_remove = [0]

--- a/src/dtscalibration/plot.py
+++ b/src/dtscalibration/plot.py
@@ -313,7 +313,7 @@ def plot_residuals_reference_sections_single(
     x_ax_avg = fig.add_subplot(grid[:2, 2:-1])  # , sharex=main_ax
     legend_ax = fig.add_subplot(grid[:2, :2], xticklabels=[], yticklabels=[])
     cbar_ax = fig.add_subplot(grid[2:, -1], xticklabels=[], yticklabels=[])
-    if np.issubdtype(resid[time_dim].dtype, np.float) or np.issubdtype(
+    if np.issubdtype(resid[time_dim].dtype, float) or np.issubdtype(
             resid[time_dim].dtype, np.int):
         resid.plot.imshow(
             ax=main_ax,


### PR DESCRIPTION
I think this should be a quick fix since `float` can be used as a drop-in replacement for `np.float`.

Should close #161 .