### PR TITLE
Fix the readme (remove dead link)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,9 +93,8 @@ Devices currently supported
 Documentation
 =============
 
-https://python-dts-calibration.readthedocs.io/
-Example notebooks can be viewed [here](https://python-dts-calibration.readthedocs.io/en/latest/learn_by_examples.html).
-
+* Documentation at https://python-dts-calibration.readthedocs.io/ .
+* Example notebooks that work within the browser can be viewed `here <https://python-dts-calibration.readthedocs.io/en/latest/learn_by_examples.html>`_.
 
 How to cite
 ===========

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Overview
       - | |version| |supported-versions| |commits-since|
     * - Citable
       - |zenodo|
+    * - Example notebooks
+      - |example-notebooks|
 
 .. |docs| image:: https://readthedocs.org/projects/python-dts-calibration/badge/?style=flat
     :target: https://python-dts-calibration.readthedocs.io/en/latest/
@@ -42,6 +44,10 @@ Overview
 .. |zenodo| image:: https://zenodo.org/badge/143077491.svg
    :alt: It would be greatly appreciated if you could cite this package in eg articles presentations
    :target: https://zenodo.org/badge/latestdoi/143077491
+
+.. |example-notebooks| image:: https://mybinder.org/badge.svg
+   :alt: Interactively run the example notebooks online
+   :target: https://mybinder.org/v2/gh/dtscalibration/python-dts-calibration/main?labpath=docs%2Fnotebooks
 
 .. end-badges
 

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,6 @@ Overview
       - | |version| |supported-versions| |commits-since|
     * - Citable
       - |zenodo|
-    * - Example notebooks
-      - |example-notebooks|
 
 .. |docs| image:: https://readthedocs.org/projects/python-dts-calibration/badge/?style=flat
     :target: https://python-dts-calibration.readthedocs.io/en/latest/


### PR DESCRIPTION
A dead link in the README.rst file made the PyPI publication fail. I have now manually published the newest version to pypi.
This PR fixes the issue.