### PR TITLE
Add mypy, use absolute imports, cleanup old pylint comments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,12 @@ Removed
 * Removed ds.resample_datastore() in favor of using xarray's resample function. See example notebook 2.
 * Removed support for Python 3.8
 
+Developer changes
+
+* Added mypy to dev dependencies and CI.
+* Changed all import statements to be absolute instead of relative.
+* Cleaned up old 'pylint: disable' comments
+
 2.0.0 (2023-05-24)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ dev = [
     "bump2version",
     "ruff",
     "isort",
+    "mypy",
+    "types-PyYAML",  # for pyyaml types
+    "types-xmltodict",  # for xmltodict types
+    "pandas-stubs",  # for pandas types
     "pytest",
     "pytest-cov",
     "jupyter",
@@ -100,6 +104,7 @@ features = ["dev"]
 lint = [
   "ruff check .",
   "isort --check-only --diff .",
+  "mypy src/",
 ]
 format = ["isort .", "lint",]
 test = ["pytest ./src/ ./tests/",]  # --doctest-modules
@@ -176,6 +181,9 @@ known_first_party = ["dtscalibration"]
 skip = [".gitignore", ".tox", "docs"]
 src_paths = ["src", "tests"]
 line_length = 120
+
+[tool.mypy]
+ignore_missing_imports = true  # Preferably false, but matplotlib, scipy and statsmodels are missing typing stubs
 
 [tool.coverage.run]
 branch = true

--- a/src/dtscalibration/__init__.py
+++ b/src/dtscalibration/__init__.py
@@ -1,22 +1,22 @@
 # coding=utf-8
-from .datastore import DataStore
-from .datastore import open_datastore
-from .datastore import open_mf_datastore
-from .datastore import read_apsensing_files
-from .datastore import read_sensornet_files
-from .datastore import read_sensortran_files
-from .datastore import read_silixa_files
-from .datastore_utils import check_dims
-from .datastore_utils import check_timestep_allclose
-from .datastore_utils import get_netcdf_encoding
-from .datastore_utils import merge_double_ended
-from .datastore_utils import shift_double_ended
-from .datastore_utils import suggest_cable_shift_double_ended
-from .plot import plot_accuracy
-from .plot import plot_location_residuals_double_ended
-from .plot import plot_residuals_reference_sections
-from .plot import plot_residuals_reference_sections_single
-from .plot import plot_sigma_report
+from dtscalibration.datastore import DataStore
+from dtscalibration.datastore import open_datastore
+from dtscalibration.datastore import open_mf_datastore
+from dtscalibration.datastore import read_apsensing_files
+from dtscalibration.datastore import read_sensornet_files
+from dtscalibration.datastore import read_sensortran_files
+from dtscalibration.datastore import read_silixa_files
+from dtscalibration.datastore_utils import check_dims
+from dtscalibration.datastore_utils import check_timestep_allclose
+from dtscalibration.datastore_utils import get_netcdf_encoding
+from dtscalibration.datastore_utils import merge_double_ended
+from dtscalibration.datastore_utils import shift_double_ended
+from dtscalibration.datastore_utils import suggest_cable_shift_double_ended
+from dtscalibration.plot import plot_accuracy
+from dtscalibration.plot import plot_location_residuals_double_ended
+from dtscalibration.plot import plot_residuals_reference_sections
+from dtscalibration.plot import plot_residuals_reference_sections_single
+from dtscalibration.plot import plot_sigma_report
 
 __version__ = '2.0.0'
 __all__ = [

--- a/src/dtscalibration/calibrate_utils.py
+++ b/src/dtscalibration/calibrate_utils.py
@@ -44,7 +44,6 @@ def parse_st_var(ds, st_var, st_label='st'):
     return st_var_sec
 
 
-# pylint: disable=too-many-arguments,too-many-locals
 def calibration_single_ended_solver(  # noqa: MC0001
         ds,
         st_var=None,
@@ -267,18 +266,18 @@ def calibration_single_ended_solver(  # noqa: MC0001
 
     if solver == 'sparse':
         if calc_cov:
-            p_sol, p_var, p_cov = wls_sparse(  # pylint: disable=unbalanced-tuple-unpacking
+            p_sol, p_var, p_cov = wls_sparse(
                 X, y, w=w, x0=p0_est_dalpha, calc_cov=calc_cov, verbose=verbose)
         else:
-            p_sol, p_var = wls_sparse(  # pylint: disable=unbalanced-tuple-unpacking
+            p_sol, p_var = wls_sparse(
                 X, y, w=w, x0=p0_est_dalpha, calc_cov=calc_cov, verbose=verbose)
 
     elif solver == 'stats':
         if calc_cov:
-            p_sol, p_var, p_cov = wls_stats(  # pylint: disable=unbalanced-tuple-unpacking
+            p_sol, p_var, p_cov = wls_stats(
                 X, y, w=w, calc_cov=calc_cov, verbose=verbose)
         else:
-            p_sol, p_var = wls_stats(  # pylint: disable=unbalanced-tuple-unpacking
+            p_sol, p_var = wls_stats(
                 X, y, w=w, calc_cov=calc_cov, verbose=verbose)
 
     elif solver == 'external':
@@ -731,7 +730,6 @@ def matching_section_location_indices(ix_sec, hix, tix):
     return ix_from_cal_match_to_glob
 
 
-# pylint: disable=too-many-statements
 def construct_submatrices_matching_sections(
         x, ix_sec, hix, tix, nt, trans_att):
     """
@@ -1039,7 +1037,6 @@ def construct_submatrices(nt, nx, ds, trans_att, x_sec):
     return E, Z_D, Z_gamma, Zero_d, Z_TA_fw, Z_TA_bw
 
 
-# pylint: disable=too-many-branches
 def wls_sparse(
         X,
         y,

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -16,25 +16,25 @@ import yaml
 from scipy.optimize import minimize
 from scipy.sparse import linalg as ln
 
-from .calibrate_utils import calc_alpha_double
-from .calibrate_utils import calibration_double_ended_solver
-from .calibrate_utils import calibration_single_ended_solver
-from .calibrate_utils import match_sections
-from .calibrate_utils import parse_st_var
-from .calibrate_utils import wls_sparse
-from .calibrate_utils import wls_stats
-from .datastore_utils import check_timestep_allclose
-from .io import _dim_attrs
-from .io import apsensing_xml_version_check
-from .io import read_apsensing_files_routine
-from .io import read_sensornet_files_routine_v3
-from .io import read_sensortran_files_routine
-from .io import read_silixa_files_routine_v4
-from .io import read_silixa_files_routine_v6
-from .io import sensornet_ddf_version_check
-from .io import sensortran_binary_version_check
-from .io import silixa_xml_version_check
-from .io import ziphandle_to_filepathlist
+from dtscalibration.calibrate_utils import calc_alpha_double
+from dtscalibration.calibrate_utils import calibration_double_ended_solver
+from dtscalibration.calibrate_utils import calibration_single_ended_solver
+from dtscalibration.calibrate_utils import match_sections
+from dtscalibration.calibrate_utils import parse_st_var
+from dtscalibration.calibrate_utils import wls_sparse
+from dtscalibration.calibrate_utils import wls_stats
+from dtscalibration.datastore_utils import check_timestep_allclose
+from dtscalibration.io import _dim_attrs
+from dtscalibration.io import apsensing_xml_version_check
+from dtscalibration.io import read_apsensing_files_routine
+from dtscalibration.io import read_sensornet_files_routine_v3
+from dtscalibration.io import read_sensortran_files_routine
+from dtscalibration.io import read_silixa_files_routine_v4
+from dtscalibration.io import read_silixa_files_routine_v6
+from dtscalibration.io import sensornet_ddf_version_check
+from dtscalibration.io import sensortran_binary_version_check
+from dtscalibration.io import silixa_xml_version_check
+from dtscalibration.io import ziphandle_to_filepathlist
 
 dtsattr_namelist = ['double_ended_flag']
 dim_attrs = {k: v for kl, v in _dim_attrs.items() for k in kl}
@@ -43,7 +43,6 @@ warnings.filterwarnings(
     message='xarray subclass DataStore should explicitly define __slots__')
 
 
-# pylint: disable=W605
 class DataStore(xr.Dataset):
     """The data class that stores the measurements, contains calibration
     methods to relate Stokes and anti-Stokes to temperature. The user should
@@ -289,7 +288,7 @@ class DataStore(xr.Dataset):
         pass
 
     @property
-    def is_double_ended(self):
+    def is_double_ended(self) -> float:
         """
         Whether or not the data is loaded from a double-ended setup.
 
@@ -303,7 +302,7 @@ class DataStore(xr.Dataset):
             # backward compatible to when only silixa files were supported
             return bool(int(self.attrs['customData:isDoubleEnded']))
         else:
-            assert 0
+            raise ValueError("Could not determine if the data was from a double-ended setup.")
 
     @is_double_ended.setter
     def is_double_ended(self, flag: bool):
@@ -311,7 +310,7 @@ class DataStore(xr.Dataset):
         pass
 
     @property
-    def chfw(self):
+    def chfw(self) -> float:
         """
         Zero based channel index of the forward measurements
 

--- a/src/dtscalibration/datastore_utils.py
+++ b/src/dtscalibration/datastore_utils.py
@@ -304,7 +304,7 @@ def shift_double_ended(ds, i_shift, verbose=True):
         With a shifted x-axis
     """
     # pylint: disable=import-outside-toplevel
-    from . import DataStore
+    from dtscalibration import DataStore
 
     assert isinstance(i_shift, (int, np.integer))
 

--- a/src/dtscalibration/datastore_utils.py
+++ b/src/dtscalibration/datastore_utils.py
@@ -269,7 +269,6 @@ def merge_double_ended_times(ds_fw, ds_bw, verify_timedeltas=True, verbose=True)
     return ds_fw.isel(time=iuse_chfw2), ds_bw.isel(time=iuse_chbw2)
 
 
-# pylint: disable=too-many-locals
 def shift_double_ended(ds, i_shift, verbose=True):
     """
     The cable length was initially configured during the DTS measurement. For double ended
@@ -303,7 +302,6 @@ def shift_double_ended(ds, i_shift, verbose=True):
     ds2 : DataStore oobject
         With a shifted x-axis
     """
-    # pylint: disable=import-outside-toplevel
     from dtscalibration import DataStore
 
     assert isinstance(i_shift, (int, np.integer))
@@ -350,7 +348,6 @@ def shift_double_ended(ds, i_shift, verbose=True):
     return DataStore(data_vars=d2_data, coords=d2_coords, attrs=ds.attrs)
 
 
-# pylint: disable=too-many-locals
 def suggest_cable_shift_double_ended(
         ds, irange, plot_result=True, **fig_kwargs):
     """The cable length was initially configured during the DTS measurement.

--- a/src/dtscalibration/io.py
+++ b/src/dtscalibration/io.py
@@ -237,7 +237,6 @@ def sensortran_binary_version_check(filepathlist):
     return version
 
 
-# pylint: disable=too-many-locals
 def read_silixa_files_routine_v6(  # noqa: MC0001
         filepathlist,
         xml_version=6,


### PR DESCRIPTION
This PR adds mypy to the dev depencencies and `hatch run lint` script, allowing us to start adding type hints.

Additionally, I have moved the code to absolute imports (relative imports can get very messy), and cleaned up some old pylint-disable comments.