### PR TITLE
Include optional dependencies from dtscalibration dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changed
 
 * Standardized parameter names. Reduced the freedom in choosing parameter names and dimension names in favor of simplifying the code.
 * Requiring netcdf4 >= 1.6.4
+* Optional dependencies of xarray that improve performance are now required by default.
 * Flox included in requirements to speed up resampling via xarray ([Xarray #5734](https://github.com/pydata/xarray/pull/5734)).
 
 Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
     "pyyaml>=6.0.1",
     "xmltodict",
     "scipy",
-    "patsy",  # a dependency of statsmodels
     "statsmodels",
     "toolz",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
     "xmltodict",
     "scipy",
     "statsmodels",
-    "toolz",
     "matplotlib",
     "netCDF4>=1.6.4",
     "nc-time-axis>=1.4.1"  # optional plot dependency of xarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.22.4",  # xarray: recommended to use >= 1.22 for full quantile method support
+    "dask",
+    "pandas",
     "xarray[parallel,accel]",
     "pyyaml>=6.0.1",
     "xmltodict",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,19 +52,17 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "numpy",
-    "xarray",
+    "numpy>=1.22.4",  # xarray: recommended to use >= 1.22 for full quantile method support
+    "xarray[parallel,accel]",
     "pyyaml>=6.0.1",
     "xmltodict",
     "scipy",
     "patsy",  # a dependency of statsmodels
     "statsmodels",
-    "dask",
     "toolz",
     "matplotlib",
     "netCDF4>=1.6.4",
-    "flox",
-    "pandas",
+    "nc-time-axis>=1.4.1"  # optional plot dependency of xarray
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Use "xarray[parallel,accel]" instead of filling up the dtscalibration dependency list with optional xarray dependencies.