### PR TITLE
Refactor sections property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ docs/_build
 .build
 .ve
 .env
+.venv
+.vscode
 .cache
 .pytest
 .bootstrap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,9 @@ test = ["pytest ./src/ ./tests/",]  # --doctest-modules
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.ruff]
 select = [  # It would be nice to have the commented out checks working.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ lint = [
 ]
 format = ["black .", "isort .", "lint",]
 test = ["pytest ./src/ ./tests/",]  # --doctest-modules
+fast-test = ["pytest ./tests/ -m \"not slow\"",]
 coverage = [
   "pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml tests/",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,13 +184,14 @@ max-complexity = 10
 py_version=39
 force_single_line = true
 known_first_party = ["dtscalibration"]
-skip = [".gitignore", ".tox", "docs"]
+skip = [".gitignore", ".tox", "docs", ".venv"]
 src_paths = ["src", "tests"]
 line_length = 120
 
 [tool.black]
 line-length = 88
 target-version = ['py39', 'py310', 'py311']
+extend-exclude = ".venv"
 
 [tool.mypy]
 ignore_missing_imports = true  # Preferably false, but matplotlib, scipy and statsmodels are missing typing stubs

--- a/src/dtscalibration/calibration/section_utils.py
+++ b/src/dtscalibration/calibration/section_utils.py
@@ -1,7 +1,10 @@
-import xarray as xr
-from typing import Dict, List
-import yaml
+from typing import Dict
+from typing import List
+
 import numpy as np
+import xarray as xr
+import yaml
+
 from dtscalibration.datastore_utils import ufunc_per_section_helper
 
 
@@ -20,9 +23,7 @@ def validate_sections(ds: xr.Dataset, sections: Dict[str, List[slice]]):
 
     # be less restrictive for capitalized labels
     # find lower cases label
-    labels = np.reshape(
-        [[s.lower(), s] for s in ds.data_vars.keys()], (-1,)
-    ).tolist()
+    labels = np.reshape([[s.lower(), s] for s in ds.data_vars.keys()], (-1,)).tolist()
 
     sections_fix = dict()
     for k, v in sections.items():
@@ -44,8 +45,7 @@ def validate_sections(ds: xr.Dataset, sections: Dict[str, List[slice]]):
 
     for k, v in sections_fix.items():
         assert isinstance(v, (list, tuple)), (
-            "The values of the sections-dictionary "
-            "should be lists of slice objects."
+            "The values of the sections-dictionary " "should be lists of slice objects."
         )
 
         for vi in v:

--- a/src/dtscalibration/calibration/section_utils.py
+++ b/src/dtscalibration/calibration/section_utils.py
@@ -1,0 +1,223 @@
+import xarray as xr
+from typing import Dict, List
+import yaml
+import numpy as np
+from dtscalibration.datastore_utils import ufunc_per_section_helper
+
+
+def set_sections(ds: xr.Dataset, sections: Dict[str, List[slice]]) -> xr.Dataset:
+    sections_validated = None
+
+    if sections is not None:
+        sections_validated = validate_sections(ds, sections=sections)
+
+    ds.attrs["_sections"] = yaml.dump(sections_validated)
+    return ds
+
+
+def validate_sections(ds: xr.Dataset, sections: Dict[str, List[slice]]):
+    assert isinstance(sections, dict)
+
+    # be less restrictive for capitalized labels
+    # find lower cases label
+    labels = np.reshape(
+        [[s.lower(), s] for s in ds.data_vars.keys()], (-1,)
+    ).tolist()
+
+    sections_fix = dict()
+    for k, v in sections.items():
+        if k.lower() in labels:
+            i_lower_case = labels.index(k.lower())
+            i_normal_case = i_lower_case + 1
+            k_normal_case = labels[i_normal_case]
+            sections_fix[k_normal_case] = v
+        else:
+            assert k in ds.data_vars, (
+                "The keys of the "
+                "sections-dictionary should "
+                "refer to a valid timeserie "
+                "already stored in "
+                "ds.data_vars "
+            )
+
+    sections_fix_slice_fixed = dict()
+
+    for k, v in sections_fix.items():
+        assert isinstance(v, (list, tuple)), (
+            "The values of the sections-dictionary "
+            "should be lists of slice objects."
+        )
+
+        for vi in v:
+            assert isinstance(vi, slice), (
+                "The values of the sections-dictionary should "
+                "be lists of slice objects."
+            )
+
+            assert ds.x.sel(x=vi).size > 0, (
+                f"Better define the {k} section. You tried {vi}, "
+                "which is not within the x-dimension"
+            )
+
+        # sorted stretches
+        stretch_unsort = [slice(float(vi.start), float(vi.stop)) for vi in v]
+        stretch_start = [i.start for i in stretch_unsort]
+        stretch_i_sorted = np.argsort(stretch_start)
+        sections_fix_slice_fixed[k] = [stretch_unsort[i] for i in stretch_i_sorted]
+
+    # Prevent overlapping slices
+    ix_sec = ufunc_per_section(
+        ds, sections=sections_fix_slice_fixed, x_indices=True, calc_per="all"
+    )
+    assert np.unique(ix_sec).size == ix_sec.size, "The sections are overlapping"
+
+    return sections_fix_slice_fixed
+
+
+def ufunc_per_section(
+    ds: xr.Dataset,
+    sections,
+    func=None,
+    label=None,
+    subtract_from_label=None,
+    temp_err=False,
+    x_indices=False,
+    ref_temp_broadcasted=False,
+    calc_per="stretch",
+    **func_kwargs,
+):
+    """
+    User function applied to parts of the cable. Super useful,
+    many options and slightly
+    complicated.
+
+    The function `func` is taken over all the timesteps and calculated
+    per `calc_per`. This
+    is returned as a dictionary
+
+    Parameters
+    ----------
+    sections : Dict[str, List[slice]], optional
+        If `None` is supplied, `ds.sections` is used. Define calibration
+        sections. Each section requires a reference temperature time series,
+        such as the temperature measured by an external temperature sensor.
+        They should already be part of the DataStore object. `sections`
+        is defined with a dictionary with its keywords of the
+        names of the reference temperature time series. Its values are
+        lists of slice objects, where each slice object is a fiber stretch
+        that has the reference temperature. Afterwards, `sections` is stored
+        under `ds.sections`.
+    func : callable, str
+        A numpy function, or lambda function to apple to each 'calc_per'.
+    label
+    subtract_from_label
+    temp_err : bool
+        The argument of the function is label minus the reference
+        temperature.
+    x_indices : bool
+        To retreive an integer array with the indices of the
+        x-coordinates in the section/stretch. The indices are sorted.
+    ref_temp_broadcasted : bool
+    calc_per : {'all', 'section', 'stretch'}
+    func_kwargs : dict
+        Dictionary with options that are passed to func
+
+    TODO: Spend time on creating a slice instead of appendng everything\
+    to a list and concatenating after.
+
+
+    Returns
+    -------
+
+    Examples
+    --------
+
+    1. Calculate the variance of the residuals in the along ALL the\
+    reference sections wrt the temperature of the water baths
+
+    >>> tmpf_var = d.ufunc_per_section(
+    >>>     func='var',
+    >>>     calc_per='all',
+    >>>     label='tmpf',
+    >>>     temp_err=True)
+
+    2. Calculate the variance of the residuals in the along PER\
+    reference section wrt the temperature of the water baths
+
+    >>> tmpf_var = d.ufunc_per_section(
+    >>>     func='var',
+    >>>     calc_per='stretch',
+    >>>     label='tmpf',
+    >>>     temp_err=True)
+
+    3. Calculate the variance of the residuals in the along PER\
+    water bath wrt the temperature of the water baths
+
+    >>> tmpf_var = d.ufunc_per_section(
+    >>>     func='var',
+    >>>     calc_per='section',
+    >>>     label='tmpf',
+    >>>     temp_err=True)
+
+    4. Obtain the coordinates of the measurements per section
+
+    >>> locs = d.ufunc_per_section(
+    >>>     func=None,
+    >>>     label='x',
+    >>>     temp_err=False,
+    >>>     ref_temp_broadcasted=False,
+    >>>     calc_per='stretch')
+
+    5. Number of observations per stretch
+
+    >>> nlocs = d.ufunc_per_section(
+    >>>     func=len,
+    >>>     label='x',
+    >>>     temp_err=False,
+    >>>     ref_temp_broadcasted=False,
+    >>>     calc_per='stretch')
+
+    6. broadcast the temperature of the reference sections to\
+    stretch/section/all dimensions. The value of the reference\
+    temperature (a timeseries) is broadcasted to the shape of self[\
+    label]. The self[label] is not used for anything else.
+
+    >>> temp_ref = d.ufunc_per_section(
+    >>>     label='st',
+    >>>     ref_temp_broadcasted=True,
+    >>>     calc_per='all')
+
+    7. x-coordinate index
+
+    >>> ix_loc = d.ufunc_per_section(x_indices=True)
+
+
+    Note
+    ----
+    If `self[label]` or `self[subtract_from_label]` is a Dask array, a Dask
+    array is returned else a numpy array is returned
+    """
+    if label is None:
+        dataarray = None
+    else:
+        dataarray = ds[label]
+
+    if x_indices:
+        x_coords = ds.x
+        reference_dataset = None
+    else:
+        x_coords = None
+        reference_dataset = {k: ds[k] for k in sections}
+
+    return ufunc_per_section_helper(
+        x_coords=x_coords,
+        sections=sections,
+        func=func,
+        dataarray=dataarray,
+        subtract_from_dataarray=subtract_from_label,
+        reference_dataset=reference_dataset,
+        subtract_reference_from_dataarray=temp_err,
+        ref_temp_broadcasted=ref_temp_broadcasted,
+        calc_per=calc_per,
+        **func_kwargs,
+    )

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -1,7 +1,5 @@
 import os
 import warnings
-from typing import Dict
-from typing import List
 
 import dask
 import dask.array as da
@@ -17,13 +15,14 @@ from dtscalibration.calibrate_utils import calibration_double_ended_helper
 from dtscalibration.calibrate_utils import calibration_single_ended_helper
 from dtscalibration.calibrate_utils import match_sections
 from dtscalibration.calibrate_utils import parse_st_var
+from dtscalibration.calibration.section_utils import set_sections
+from dtscalibration.calibration.section_utils import validate_sections
 from dtscalibration.datastore_utils import ParameterIndexDoubleEnded
 from dtscalibration.datastore_utils import ParameterIndexSingleEnded
 from dtscalibration.datastore_utils import check_deprecated_kwargs
 from dtscalibration.datastore_utils import check_timestep_allclose
 from dtscalibration.datastore_utils import ufunc_per_section_helper
 from dtscalibration.io_utils import _dim_attrs
-from dtscalibration.calibration.section_utils import set_sections, validate_sections
 
 dtsattr_namelist = ["double_ended_flag"]
 dim_attrs = {k: v for kl, v in _dim_attrs.items() for k in kl}

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -17,10 +17,10 @@ from dtscalibration import read_apsensing_files
 from dtscalibration import read_sensornet_files
 from dtscalibration import read_sensortran_files
 from dtscalibration import read_silixa_files
+from dtscalibration.calibration.section_utils import set_sections
 from dtscalibration.datastore_utils import merge_double_ended
 from dtscalibration.datastore_utils import shift_double_ended
 from dtscalibration.datastore_utils import suggest_cable_shift_double_ended
-from dtscalibration.calibration.section_utils import set_sections
 
 np.random.seed(0)
 
@@ -168,8 +168,11 @@ def test_sections_property():
     ds = set_sections(
         ds,
         {
-            "probe1Temperature": [slice(np.array(0.0), np.array(17.0)), slice(70.0, 80.0)]
-        }
+            "probe1Temperature": [
+                slice(np.array(0.0), np.array(17.0)),
+                slice(70.0, 80.0),
+            ]
+        },
     )
 
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -20,6 +20,7 @@ from dtscalibration import read_silixa_files
 from dtscalibration.datastore_utils import merge_double_ended
 from dtscalibration.datastore_utils import shift_double_ended
 from dtscalibration.datastore_utils import suggest_cable_shift_double_ended
+from dtscalibration.calibration.section_utils import set_sections
 
 np.random.seed(0)
 
@@ -156,21 +157,20 @@ def test_sections_property():
         "probe1Temperature": [slice(0.0, 17.0), slice(70.0, 80.0)],  # cold bath
         "probe2Temperature": [slice(24.0, 34.0), slice(85.0, 95.0)],  # warm bath
     }
-    ds.sections = sections1
+    ds = set_sections(ds, sections1)
 
-    assert isinstance(ds._sections, str)
+    assert isinstance(ds.attrs["_sections"], str)
 
     assert ds.sections == sections1
     assert ds.sections != sections2
 
     # test if accepts singleton numpy arrays
-    ds.sections = {
-        "probe1Temperature": [slice(np.array(0.0), np.array(17.0)), slice(70.0, 80.0)]
-    }
-
-    # delete property
-    del ds.sections
-    assert ds.sections is None
+    ds = set_sections(
+        ds,
+        {
+            "probe1Temperature": [slice(np.array(0.0), np.array(17.0)), slice(70.0, 80.0)]
+        }
+    )
 
 
 def test_io_sections_property():
@@ -190,7 +190,7 @@ def test_io_sections_property():
     }
     ds["x"].attrs["units"] = "m"
 
-    ds.sections = sections
+    ds = set_sections(ds, sections)
 
     # Create a temporary file to write data to.
     # 'with' method is used so the file is closed by tempfile

--- a/tests/test_dtscalibration.py
+++ b/tests/test_dtscalibration.py
@@ -57,6 +57,7 @@ def assert_almost_equal_verbose(actual, desired, verbose=False, **kwargs):
     pass
 
 
+@pytest.mark.slow  # Execution time ~20 seconds
 def test_variance_input_types_single():
     import dask.array as da
 
@@ -222,6 +223,7 @@ def test_variance_input_types_single():
     pass
 
 
+@pytest.mark.slow  # Execution time ~0.5 minute
 def test_variance_input_types_double():
     import dask.array as da
 
@@ -454,6 +456,7 @@ def test_variance_input_types_double():
     pass
 
 
+@pytest.mark.slow  # Execution time ~0.5 minute
 def test_double_ended_variance_estimate_synthetic():
     import dask.array as da
 
@@ -780,6 +783,7 @@ def test_variance_of_stokes_synthetic():
     pass
 
 
+@pytest.mark.slow  # Execution time ~20 seconds
 def test_variance_of_stokes_linear_synthetic():
     """
     Produces a synthetic Stokes measurement with a known noise distribution.
@@ -851,6 +855,7 @@ def test_variance_of_stokes_linear_synthetic():
     pass
 
 
+@pytest.mark.slow  # Execution time ~20 seconds
 def test_exponential_variance_of_stokes():
     correct_var = 11.86535
     filepath = data_dir_double_ended2
@@ -2556,6 +2561,7 @@ def test_double_ended_exponential_variance_estimate_synthetic():
     pass
 
 
+@pytest.mark.slow  # Execution time ~2 minutes.
 def test_estimate_variance_of_temperature_estimate():
     import dask.array as da
 
@@ -3591,12 +3597,11 @@ def test_average_measurements_single_ended():
 
     ds = ds_.sel(x=slice(0, 100))  # only calibrate parts of the fiber
     sections = {"probe2Temperature": [slice(6.0, 14.0)]}  # warm bath
-    ds = set_sections(ds, sections)
 
     st_var, ast_var = 5.0, 5.0
 
     ds.calibration_single_ended(
-        st_var=st_var, ast_var=ast_var, method="wls", solver="sparse"
+        sections=sections, st_var=st_var, ast_var=ast_var, method="wls", solver="sparse"
     )
     ds.average_single_ended(
         p_val="p_val",

--- a/tests/test_dtscalibration.py
+++ b/tests/test_dtscalibration.py
@@ -10,6 +10,7 @@ from dtscalibration import DataStore
 from dtscalibration import read_silixa_files
 from dtscalibration.calibrate_utils import wls_sparse
 from dtscalibration.calibrate_utils import wls_stats
+from dtscalibration.calibration.section_utils import set_sections
 
 np.random.seed(0)
 
@@ -1089,10 +1090,10 @@ def test_double_ended_wls_estimate_synthetic_df_and_db_are_different():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds.sections = {
+    ds = set_sections(ds, {
         "cold": [slice(0.0, 0.09 * cable_len)],
         "warm": [slice(0.9 * cable_len, cable_len)],
-    }
+    })
 
     real_ans2 = np.concatenate(([gamma], df, db, E_real[:, 0]))
 
@@ -1207,10 +1208,10 @@ def test_reneaming_old_default_labels_to_new_fixed_labels():
     )
     ds = ds.rename_labels()
 
-    ds.sections = {
+    ds = set_sections(ds, {
         "cold": [slice(0.0, 0.09 * cable_len)],
         "warm": [slice(0.9 * cable_len, cable_len)],
-    }
+    })
 
     real_ans2 = np.concatenate(([gamma], df, db, E_real[:, 0]))
 
@@ -1312,10 +1313,10 @@ def test_fail_if_st_labels_are_passed_to_calibration_function():
     )
     ds = ds.rename_labels()
 
-    ds.sections = {
+    ds = set_sections(ds, {
         "cold": [slice(0.0, 0.09 * cable_len)],
         "warm": [slice(0.9 * cable_len, cable_len)],
-    }
+    })
 
     ds.calibration_double_ended(
         st_label="ST",
@@ -1418,13 +1419,13 @@ def test_double_ended_asymmetrical_attenuation():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds.sections = {
+    ds = set_sections(ds, {
         "cold": [slice(0.0, x[nx_per_sec - 1]), slice(x[-nx_per_sec], x[-1])],
         "warm": [
             slice(x[nx_per_sec], x[2 * nx_per_sec - 1]),
             slice(x[-2 * nx_per_sec], x[-1 * nx_per_sec - 1]),
         ],
-    }
+    })
 
     ds.calibration_double_ended(
         st_var=1.5,
@@ -1554,10 +1555,10 @@ def test_double_ended_one_matching_section_and_one_asym_att():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds.sections = {
+    ds = set_sections(ds, {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    }
+    })
 
     ds.calibration_double_ended(
         st_var=1.5,
@@ -1672,10 +1673,10 @@ def test_double_ended_two_matching_sections_and_two_asym_atts():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds.sections = {
+    ds = set_sections(ds, {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    }
+    })
     ms = [
         (
             slice(x[2 * nx_per_sec], x[3 * nx_per_sec - 1]),
@@ -2077,10 +2078,10 @@ def test_double_ended_fix_alpha_matching_sections_and_one_asym_att():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds.sections = {
+    ds = set_sections(ds, {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    }
+    })
 
     ds.calibration_double_ended(
         st_var=1.5,
@@ -2215,10 +2216,10 @@ def test_double_ended_fix_alpha_gamma_matching_sections_and_one_asym_att():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds.sections = {
+    ds = set_sections(ds, {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    }
+    })
 
     ds.calibration_double_ended(
         st_var=1.5,
@@ -2354,10 +2355,10 @@ def test_double_ended_fix_gamma_matching_sections_and_one_asym_att():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds.sections = {
+    ds = set_sections(ds, {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    }
+    })
 
     ds.calibration_double_ended(
         st_var=1.5,
@@ -3578,7 +3579,7 @@ def test_average_measurements_single_ended():
 
     ds = ds_.sel(x=slice(0, 100))  # only calibrate parts of the fiber
     sections = {"probe2Temperature": [slice(6.0, 14.0)]}  # warm bath
-    ds.sections = sections
+    ds = set_sections(ds, sections)
 
     st_var, ast_var = 5.0, 5.0
 
@@ -3645,7 +3646,7 @@ def test_average_measurements_double_ended():
         "probe1Temperature": [slice(7.5, 17.0), slice(70.0, 80.0)],  # cold bath
         "probe2Temperature": [slice(24.0, 34.0), slice(85.0, 95.0)],  # warm bath
     }
-    ds.sections = sections
+    ds = set_sections(ds, sections)
 
     st_var, ast_var, rst_var, rast_var = 5.0, 5.0, 5.0, 5.0
 

--- a/tests/test_dtscalibration.py
+++ b/tests/test_dtscalibration.py
@@ -10,7 +10,6 @@ from dtscalibration import DataStore
 from dtscalibration import read_silixa_files
 from dtscalibration.calibrate_utils import wls_sparse
 from dtscalibration.calibrate_utils import wls_stats
-from dtscalibration.calibration.section_utils import set_sections
 
 np.random.seed(0)
 

--- a/tests/test_dtscalibration.py
+++ b/tests/test_dtscalibration.py
@@ -1090,14 +1090,15 @@ def test_double_ended_wls_estimate_synthetic_df_and_db_are_different():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds = set_sections(ds, {
+    sections = {
         "cold": [slice(0.0, 0.09 * cable_len)],
         "warm": [slice(0.9 * cable_len, cable_len)],
-    })
+    }
 
     real_ans2 = np.concatenate(([gamma], df, db, E_real[:, 0]))
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -1208,14 +1209,15 @@ def test_reneaming_old_default_labels_to_new_fixed_labels():
     )
     ds = ds.rename_labels()
 
-    ds = set_sections(ds, {
+    sections = {
         "cold": [slice(0.0, 0.09 * cable_len)],
         "warm": [slice(0.9 * cable_len, cable_len)],
-    })
+    }
 
     real_ans2 = np.concatenate(([gamma], df, db, E_real[:, 0]))
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -1313,12 +1315,13 @@ def test_fail_if_st_labels_are_passed_to_calibration_function():
     )
     ds = ds.rename_labels()
 
-    ds = set_sections(ds, {
+    sections = {
         "cold": [slice(0.0, 0.09 * cable_len)],
         "warm": [slice(0.9 * cable_len, cable_len)],
-    })
+    }
 
     ds.calibration_double_ended(
+        sections=sections,
         st_label="ST",
         ast_label="AST",
         rst_label="REV-ST",
@@ -1419,15 +1422,16 @@ def test_double_ended_asymmetrical_attenuation():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds = set_sections(ds, {
+    sections = {
         "cold": [slice(0.0, x[nx_per_sec - 1]), slice(x[-nx_per_sec], x[-1])],
         "warm": [
             slice(x[nx_per_sec], x[2 * nx_per_sec - 1]),
             slice(x[-2 * nx_per_sec], x[-1 * nx_per_sec - 1]),
         ],
-    })
+    }
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -1457,6 +1461,7 @@ def test_double_ended_asymmetrical_attenuation():
 
     # About to be depreciated
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -1555,12 +1560,13 @@ def test_double_ended_one_matching_section_and_one_asym_att():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds = set_sections(ds, {
+    sections = {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    })
+    }
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -1673,10 +1679,10 @@ def test_double_ended_two_matching_sections_and_two_asym_atts():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds = set_sections(ds, {
+    sections = {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    })
+    }
     ms = [
         (
             slice(x[2 * nx_per_sec], x[3 * nx_per_sec - 1]),
@@ -1691,6 +1697,7 @@ def test_double_ended_two_matching_sections_and_two_asym_atts():
     ]
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=0.5,
         ast_var=0.5,
         rst_var=0.1,
@@ -2078,12 +2085,13 @@ def test_double_ended_fix_alpha_matching_sections_and_one_asym_att():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds = set_sections(ds, {
+    sections = {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    })
+    }
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -2110,6 +2118,7 @@ def test_double_ended_fix_alpha_matching_sections_and_one_asym_att():
     alpha_var_adj = ds.alpha_var.values.copy()
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -2216,12 +2225,13 @@ def test_double_ended_fix_alpha_gamma_matching_sections_and_one_asym_att():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds = set_sections(ds, {
+    sections = {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    })
+    }
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -2248,6 +2258,7 @@ def test_double_ended_fix_alpha_gamma_matching_sections_and_one_asym_att():
     alpha_var_adj = ds.alpha_var.values.copy()
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -2355,12 +2366,13 @@ def test_double_ended_fix_gamma_matching_sections_and_one_asym_att():
         attrs={"isDoubleEnded": "1"},
     )
 
-    ds = set_sections(ds, {
+    sections = {
         "cold": [slice(0.0, x[nx_per_sec - 1])],
         "warm": [slice(x[nx_per_sec], x[2 * nx_per_sec - 1])],
-    })
+    }
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=1.5,
         ast_var=1.5,
         rst_var=1.0,
@@ -3646,11 +3658,11 @@ def test_average_measurements_double_ended():
         "probe1Temperature": [slice(7.5, 17.0), slice(70.0, 80.0)],  # cold bath
         "probe2Temperature": [slice(24.0, 34.0), slice(85.0, 95.0)],  # warm bath
     }
-    ds = set_sections(ds, sections)
 
     st_var, ast_var, rst_var, rast_var = 5.0, 5.0, 5.0, 5.0
 
     ds.calibration_double_ended(
+        sections=sections,
         st_var=st_var,
         ast_var=ast_var,
         rst_var=rst_var,


### PR DESCRIPTION
- sections is now a required argument when calling `calibration_*_ended`
- only the calibration methods set the sections attr

<hr>

Closes #196 :
I also added markers to slow tests. By skipping the slow tests, the test suite runs in 1 minute on my machine. This is a lot faster than with all tests, which took >5 minutes.

I skipped the 6 slowest ones. This skips some of the variance tests, but not all of them, so that should be fine when trying to debug other parts of the code base.

![afbeelding](https://github.com/dtscalibration/python-dts-calibration/assets/12114825/f91720c1-f173-4396-83a0-1cbeb49aefbb)
